### PR TITLE
Correção campo Espécie - Boleto Bradesco

### DIFF
--- a/src/OpenBoleto/Banco/Bradesco.php
+++ b/src/OpenBoleto/Banco/Bradesco.php
@@ -47,6 +47,13 @@ class Bradesco extends BoletoAbstract
     protected $codigoBanco = '237';
 
     /**
+     * @var array Nome espécie das moedas
+     */
+    protected static $especie = array(
+        self::MOEDA_REAL => 'R$'
+    );
+
+    /**
      * Localização do logotipo do banco, referente ao diretório de imagens
      * @var string
      */


### PR DESCRIPTION
O Banco Bradesco informou que o campo "espécie", no boleto gerado, precisa estar como R$ e não como REAL, como estava antes.
Card relacionado: https://app.pipefy.com/open-cards/423101757