### PR TITLE
[PROD] hotfix/card-799789527 - Subir em 02/10/2023

### DIFF
--- a/src/OpenBoleto/Banco/Santander.php
+++ b/src/OpenBoleto/Banco/Santander.php
@@ -69,7 +69,7 @@ class Santander extends BoletoAbstract
      * Define os nomes das carteiras para exibição no boleto
      * @var array
      */
-    protected $carteirasNomes = array('101' => 'Cobrança Simples ECR', '102' => 'Cobrança Simples CSR');
+    protected $carteirasNomes = array('101' => 'Cobrança Simples Rápida com Registro', '102' => 'Cobrança Simples CSR');
 
     /**
      * Define o valor do IOS - Seguradoras (Se 7% informar 7. Limitado a 9%) - Demais clientes usar 0 (zero)


### PR DESCRIPTION
No boleto, a descrição da Carteira 101 consta com a descrição antiga e foi solicitado pelo banco que a alteração fosse realizada conforme [CARD](https://app.pipefy.com/open-cards/799789527).